### PR TITLE
add future plans

### DIFF
--- a/app/meetings/templates/tba.html
+++ b/app/meetings/templates/tba.html
@@ -9,9 +9,26 @@
 </head>
 
 <body>
-<h1>To be announced!</h1>
-<p>We haven't put together the agenda for the next meeting yet.</p>
 <p><u>Next meeting date</u>: <b>Monday, {{ meeting_date }}</b></p>
 
+<p>Agenda to be announced!</p>
+<p>We haven't put together the agenda for the next meeting yet, but here's what we're thinking...</p>
+<p>
+Future meetings will include talks on:
+<ul>
+<li>data visualization in Pandas</li>
+<li>crash courses in deep learning</li>
+<li>learn python from scratch</li>
+<li>Embrace error: how error foo can advance your coding, and beyond!</li>
+</ul>
+Plus installments of our ongoing series:
+<ul>
+<li>"Future of Coding" explores automated transformation of source code.</li>
+<li>"Demysti-py" looks at how familiar constructs are implemented.</li>
+<li>"Pythonic pitfalls" improves both your code and your fundamentals.</li>
+<li>"Deep reading" explores and applies academic articles on deep learning.</li>
+<li>"New tool roundup" by our resident code hound keeps you updated.</li>
+</ul>
+</p>
 </body>
 </html>


### PR DESCRIPTION
We are giving the "next-meeting' link to sister groups, so expect more action for this template.  Thus it would be great to include everything we know about our future plans in order to pique visitor interest.  We can hardcode these two lists here, or if you prefer, we can pull the lists from two tables.  My thinking is that things are early and fluid enough that the easier hardcoding route is fine for now.  Or an intermediate route could be to define a future_plans html slug, cuz that would be useful in the monthly meeting announcement as well as here [assuming we can pull such a slug into the monthly "newsletter"].