### PR TITLE
next_meeting_can_be_today 

### DIFF
--- a/app/homepage/views.py
+++ b/app/homepage/views.py
@@ -20,7 +20,7 @@ class Home(TemplateView):
             pass
         try:
             meeting = Meeting.objects.filter(
-                date__isnull=False, date__gt=today(datetime.timezone.utc)
+                date__isnull=False, date__gte=today(datetime.timezone.utc)
             ).earliest("date")
             context["when"] = make_when(meeting.date)
         except Meeting.DoesNotExist:


### PR DESCRIPTION
for folks hurriedly checking, on the actual meeting date, whether they missed this week's meeting, who currently find the meeting date for next month.